### PR TITLE
now SCF return to normal options after convergence

### DIFF
--- a/lioamber/SCF.f90
+++ b/lioamber/SCF.f90
@@ -908,6 +908,7 @@ subroutine SCF(E)
       if (changed_to_LS) then
          changed_to_LS=.false.
          NMAX=NMAX/2
+         Rho_LS=0
       end if
 
       if (noconverge.gt.4) then


### PR DESCRIPTION
included a forgotten change for return to normal options for convergence in multiple SCF calls